### PR TITLE
Code that fixes CSTP conductance decay bug

### DIFF
--- a/carlsim/kernel/inc/snn.h
+++ b/carlsim/kernel/inc/snn.h
@@ -1054,7 +1054,7 @@ private:
 	void doCurrentUpdateD2_GPU(int netId) { assert(false); }
 	void doSTPUpdateAndDecayCond_GPU(int netId) { assert(false); }
 	void deleteRuntimeData_GPU(int netId) { assert(false); }		//!< deallocates all used data structures in snn_gpu.cu
-	void findFiring_GPU(int netId) { assert(false); }
+	void findFiring_GPU(int netId) { assert(false); }	
 	void globalStateUpdate_C_GPU(int netId) { assert(false); }
 	void globalStateUpdate_N_GPU(int netId) { assert(false); }
 	void globalStateUpdate_G_GPU(int netId) { assert(false); }
@@ -1166,6 +1166,7 @@ private:
 	void convertExtSpikesD1_CPU(int netId, int startIdx, int endIdx, int GtoLOffset);
 	void doCurrentUpdateD2_CPU(int netId);
 	void doCurrentUpdateD1_CPU(int netId);
+	void test1(int netId);
 	void doSTPUpdateAndDecayCond_CPU(int netId);
 	void deleteRuntimeData_CPU(int netId);
 	void findFiring_CPU(int netId);
@@ -1182,6 +1183,7 @@ private:
 	void* convertExtSpikesD1_CPU(int netId, int startIdx, int endIdx, int GtoLOffset);
 	void* doCurrentUpdateD2_CPU(int netId);
 	void* doCurrentUpdateD1_CPU(int netId);
+	void test1(int netId);
 	void* doSTPUpdateAndDecayCond_CPU(int netId);
 	void* deleteRuntimeData_CPU(int netId);
 	void* findFiring_CPU(int netId);

--- a/carlsim/kernel/inc/snn_datastructures.h
+++ b/carlsim/kernel/inc/snn_datastructures.h
@@ -771,6 +771,16 @@ typedef struct RuntimeData_s {
 	float* gGABAb_r;
 	float* gGABAb_d;
 
+#ifdef JK_CA3_SNN
+	// NS addition
+	float* AMPA_syn_g;	
+	float* NMDA_d_syn_g;
+	float* NMDA_r_syn_g;
+	float* GABAa_syn_g;
+	float* GABAb_d_syn_g;
+	float* GABAb_r_syn_g;
+#endif	
+
 	int* I_set; //!< an array of bits indicating which synapse got a spike
 
 	MemType memType;
@@ -930,6 +940,10 @@ typedef struct NetworkConfigRT_s  {
 	// configurations for runtime data sizes
 	unsigned int I_setLength; //!< used for GPU only
 	size_t       I_setPitch;  //!< used for GPU only
+#if JK_CA3_SNN
+	unsigned int syn_gLength; //!< used for GPU only
+	size_t       syn_gPitch;  //!< used for GPU only	
+#endif
 	size_t       STP_Pitch;   //!< numN rounded upwards to the nearest 256 boundary, used for GPU only
 	int numPostSynNet;        //!< the total number of post-connections in a network
 	int numPreSynNet;         //!< the total number of pre-connections in a network

--- a/carlsim/kernel/src/snn_cpu_module.cpp
+++ b/carlsim/kernel/src/snn_cpu_module.cpp
@@ -3114,6 +3114,25 @@ void SNN::copyAuxiliaryData(int netId, int lGrpId, RuntimeData* dest, bool alloc
 	assert(networkConfigs[netId].maxNumPreSynN >= 0);
 	memset(dest->I_set, 0, sizeof(int) * networkConfigs[netId].numNReg * networkConfigs[netId].I_setLength);
 
+#if JK_CA3_SNN
+	if(allocateMem) {
+		networkConfigs[netId].syn_gLength = networkConfigs[netId].maxNumPreSynN;
+		dest->AMPA_syn_g = new float[networkConfigs[netId].numNReg * networkConfigs[netId].syn_gLength];
+		dest->NMDA_d_syn_g = new float[networkConfigs[netId].numNReg * networkConfigs[netId].syn_gLength];
+		dest->NMDA_r_syn_g = new float[networkConfigs[netId].numNReg * networkConfigs[netId].syn_gLength];
+		dest->GABAa_syn_g = new float[networkConfigs[netId].numNReg * networkConfigs[netId].syn_gLength];
+		dest->GABAb_d_syn_g = new float[networkConfigs[netId].numNReg * networkConfigs[netId].syn_gLength];
+		dest->GABAb_r_syn_g = new float[networkConfigs[netId].numNReg * networkConfigs[netId].syn_gLength];		
+	}
+	assert(networkConfigs[netId].maxNumPreSynN >= 0);
+	memset(dest->AMPA_syn_g, 0, networkConfigs[netId].numNReg * networkConfigs[netId].syn_gLength);
+	memset(dest->NMDA_d_syn_g, 0, networkConfigs[netId].numNReg * networkConfigs[netId].syn_gLength);
+	memset(dest->NMDA_r_syn_g, 0, networkConfigs[netId].numNReg * networkConfigs[netId].syn_gLength);	
+	memset(dest->GABAa_syn_g, 0, networkConfigs[netId].numNReg * networkConfigs[netId].syn_gLength);
+	memset(dest->GABAb_d_syn_g, 0, networkConfigs[netId].numNReg * networkConfigs[netId].syn_gLength);
+	memset(dest->GABAb_r_syn_g, 0, networkConfigs[netId].numNReg * networkConfigs[netId].syn_gLength);	
+#endif
+
 	// synSpikeTime: an array indicates the last time when a synapse got a spike
 	if(allocateMem)
 		dest->synSpikeTime = new int[networkConfigs[netId].numPreSynNet];
@@ -3587,6 +3606,14 @@ void SNN::copySpikeTables(int netId) {
 	delete [] runtimeData[netId].postSynapticIds;
 	delete [] runtimeData[netId].preSynapticIds;
 	delete [] runtimeData[netId].I_set;
+#if JK_CA3_SNN
+	delete [] runtimeData[netId].AMPA_syn_g;
+	delete [] runtimeData[netId].NMDA_d_syn_g;
+	delete [] runtimeData[netId].NMDA_r_syn_g;
+	delete [] runtimeData[netId].GABAa_syn_g;
+	delete [] runtimeData[netId].GABAb_d_syn_g;
+	delete [] runtimeData[netId].GABAb_r_syn_g;
+#endif	
 	delete [] runtimeData[netId].poissonFireRate;
 	delete [] runtimeData[netId].lastSpikeTime;
 	delete [] runtimeData[netId].spikeGenBits;

--- a/carlsim/kernel/src/snn_manager.cpp
+++ b/carlsim/kernel/src/snn_manager.cpp
@@ -64,6 +64,7 @@
 #include <spike_buffer.h>
 #include <error_code.h>
 
+
 // \FIXME what are the following for? why were they all the way at the bottom of this file?
 
 #define COMPACTION_ALIGNMENT_PRE  16
@@ -1263,6 +1264,7 @@ int SNN::runNetwork(int _nsec, int _nmsec, bool printRunSummary) {
 	CUDA_RESET_TIMER(timer);
 	CUDA_START_TIMER(timer);
 #endif
+
 
 	//KERNEL_INFO("Reached the advSimStep loop!");
 
@@ -2764,7 +2766,7 @@ void SNN::doSTPUpdateAndDecayCond() {
 		cpu_set_t cpus;
 		ThreadStruct argsThreadRoutine[numCores + 1]; // same as above, +1 array size
 		int threadCount = 0;
-	#endif
+	#endif		
 
 	for (int netId = 0; netId < MAX_NET_PER_SNN; netId++) {
 		if (!groupPartitionLists[netId].empty()) {

--- a/carlsim/testca3/CMakeLists.txt
+++ b/carlsim/testca3/CMakeLists.txt
@@ -5,6 +5,7 @@
 # Targets
 
     add_executable(carlsim-testsca3
+        ca3cstp_taud.cpp
         carlsim_tests_common.cpp      
         ca3cstp.cpp
 		ca3types.h

--- a/carlsim/testca3/CMakeLists.txt
+++ b/carlsim/testca3/CMakeLists.txt
@@ -6,6 +6,7 @@
 
     add_executable(carlsim-testsca3
         ca3cstp_taud.cpp
+        ca3cstp_perf.cpp
         carlsim_tests_common.cpp      
         ca3cstp.cpp
 		ca3types.h

--- a/carlsim/testca3/ca3cstp_perf.cpp
+++ b/carlsim/testca3/ca3cstp_perf.cpp
@@ -1,0 +1,109 @@
+/*
+Test of CSTP processing performance
+
+Concept: 
+Test that checks the processing speed of CSTP code meets a certain processing time.
+*/
+
+#include "gtest/gtest.h"
+#include "carlsim_tests.h"
+#include <carlsim.h>
+
+// Include libraries that will allow for us to perform vector operations, and
+// print their results
+#include <iostream>
+#include <algorithm>
+#include <vector>
+#include <boost/iterator/counting_iterator.hpp>
+#include <ctime>
+#include <time.h>
+#include <cstdlib>
+
+// Create a function that will print out all of the elements of a vector
+void print(std::vector <int> const &a) {
+ std::cout << "The vector elements are : ";
+ for(int i=0; i < a.size(); i++)
+		std::cout << a.at(i) << ' ';
+}
+
+// Create a function that will create a subset of a vector, which will can be
+// used in defining Poisson rates for a fraction of neurons in a group
+template<typename T>
+std::vector<T> slice(std::vector<T> &v, int m, int n)
+{
+    std::vector<T> vec;
+    std::copy(v.begin() + m, v.begin() + n + 1, std::back_inserter(vec));
+    return vec;
+}
+
+TEST(CA3, cstp_perf) {   
+	clock_t t = clock();
+	::testing::FLAGS_gtest_death_test_style = "threadsafe";
+	// ---------------- CONFIG STATE -------------------
+	// create a network on GPU
+	int numGPUs = 0;
+	int randSeed = 10;
+	CARLsim sim("ca3_snn_GPU", GPU_MODE, USER, numGPUs, randSeed);
+	const ComputingBackend BACKEND_CORES = GPU_CORES;
+	// include header file that contains generation of groups and their properties
+	#include "generateCONFIGStateSTP.h"
+	// Set the time constants for the excitatory and inhibitory receptors, and
+	// set the method of integration to numerically solve the systems of ODEs
+	// involved in the SNN
+	sim.setIntegrationMethod(RUNGE_KUTTA4, 5);
+	// Setting simulation mode to COBA because conductances are needed for the tm synapse model
+	sim.setConductances(true);
+	// ---------------- SETUP STATE -------------------
+	// build the network
+	sim.setupNetwork();
+	// Declare variables that will store the start and end ID for the neurons
+	// in the pyramidal group
+	int pyr_start = sim.getGroupStartNeuronId(CA3_Pyramidal);
+	//std::cout << "Beginning neuron ID for Pyramidal Cells is : " << pyr_start << "\n";
+	int pyr_end = sim.getGroupEndNeuronId(CA3_Pyramidal);
+	//std::cout << "Ending neuron ID for Pyramidal Cells is : " << pyr_end << "\n";
+	int pyr_range = (pyr_end - pyr_start) + 1;
+	//std::cout << "The range for Pyramidal Cells is : " << pyr_range << "\n";
+	// Create vectors that are the length of the number of neurons in the pyramidal
+	// group, and another that will store the current at the position for the
+  	// random pyramidal cells that will be selected
+	std::vector<int> pyr_vec( boost::counting_iterator<int>( 0 ),
+													 boost::counting_iterator<int>( pyr_range ));
+  	std::vector<float> current(pyr_range, 0.0f);
+	// include header file that contains generation of groups and their properties
+	#include "generateSETUPStateSTP.h"
+	// Define the number of neurons to receive input from the external current
+	int numPyramidalFire = 10000;
+	// Set the seed of the pseudo-random number generator based on the current system time
+	std::srand(std::time(nullptr));
+	// Set external current for a fraction of pyramidal cells based on the random seed
+	for (int i = 0; i < numPyramidalFire; i++)
+	{
+	int randPyrCell = pyr_vec.front() + ( std::rand() % ( pyr_vec.back() - pyr_vec.front() ) );
+	current.at(randPyrCell) = 0.000035f;
+	}
+	// ---------------- RUN STATE -------------------
+	// run for a total of 10 seconds in 500ms bins
+	for (int i = 0; i < 9*2; i++) {
+		if (i == 0) {
+			//// alternative input from DG
+			sim.setExternalCurrent(CA3_Pyramidal, 40.0f);
+			sim.setExternalCurrent(CA3_Axo_Axonic, 100.0f);
+			sim.setExternalCurrent(CA3_BC_CCK, 135.0f);
+			sim.setExternalCurrent(CA3_Basket, 440.0f); 
+			sim.setExternalCurrent(CA3_Bistratified, 135.0f);
+			sim.setExternalCurrent(CA3_Ivy, 500.0f);
+			sim.setExternalCurrent(CA3_QuadD_LM, 200.0f);
+			sim.setExternalCurrent(CA3_MFA_ORDEN, 250.0f);
+
+			sim.runNetwork(0, 500, false);
+		} 
+		else if (i > 0) {			
+			sim.runNetwork(0, 500, false);
+		}
+	}
+	t = clock() - t;
+
+	// Test that the simulation ran in a desired amount of time (less than 20 sec)
+	EXPECT_LT(((float)t)/CLOCKS_PER_SEC, 20); 
+}

--- a/carlsim/testca3/ca3cstp_taud.cpp
+++ b/carlsim/testca3/ca3cstp_taud.cpp
@@ -1,0 +1,120 @@
+/*
+Tau_d effect specific to each synapse connection
+
+Concept: 
+Test that each synapse connection in connection-specific short-term placticity (CSTP)
+is multiplied by its own tau_d. Also that the tau_d of one connection does not affect
+the current decay rate of another connection.
+*/
+
+#include "gtest/gtest.h"
+#include "carlsim_tests.h"
+#include <carlsim.h>
+
+TEST(CA3, cstp_taud) {   
+	::testing::FLAGS_gtest_death_test_style = "threadsafe";
+
+	/* Test 1: One Synapse Connection */
+
+	// ---------------- CONFIG STATE -------------------
+	LoggerMode logger = SILENT;  // USER, SILENT
+	int numGPUs = 0;
+	int randSeed = 42;	
+	//CARLsim sim("cstp_test_1conn", GPU_MODE, USER, numGPUs, randSeed);
+	CARLsim* sim = new CARLsim("cstp_test_1conn", GPU_MODE, logger, numGPUs, randSeed);
+	int EC_LI_II_Multipolar_Pyramidal=sim->createGroup("EC_LI_II_Multipolar_Pyramidal", 
+	                            1, EXCITATORY_NEURON, ANY, GPU_CORES);  
+	int MEC_LII_Stellate=sim->createGroup("MEC_LII_Stellate", 
+	                            1, EXCITATORY_NEURON, ANY, GPU_CORES);	
+	sim->setNeuronParameters(EC_LI_II_Multipolar_Pyramidal, 204.0f, 0.0f, 0.37f, 0.0f, -70.53f, 0.0f, -39.99f, 
+	                                0.0f, 0.001f, 0.0f, 0.01f, 0.0f, 3.96f, 0.0f, -54.95f, 0.0f, 
+	                                7.0f, 0.0f, 1); // C,k,vr,vt,a,b,vpeak,c,d
+	sim->setNeuronParameters(MEC_LII_Stellate, 118.0f, 0.0f, 0.98f, 0.0f, -58.53f, 0.0f, -43.52f, 
+	                                0.0f, 0.004f, 0.0f, 7.0f, 0.0f, 7.85f, 0.0f, -52.68f, 0.0f, 
+	                                65.0f, 0.0f, 1);
+	/* neuron connection parameters */
+	sim->connect(EC_LI_II_Multipolar_Pyramidal, MEC_LII_Stellate, "one-to-one", 50.0f, 1.0f, 
+	    RangeDelay(1), RadiusRF(-1), SYN_FIXED, 1, 1);
+	sim->setSTP(EC_LI_II_Multipolar_Pyramidal, MEC_LII_Stellate, true, STPu(0.1513, 0.0f),
+	                                     STPtauU(69.11, 0.0f),
+	                                     STPtauX(98.1, 0.0f),
+	                                     STPtdAMPA(6.0, 0.0f),
+	                                     STPtdNMDA(150.0, 0.0f),
+	                                     STPtdGABAa(5.0, 0.0f),
+	                                     STPtdGABAb(150.0, 0.0f),
+	                                     STPtrNMDA(0.0f, 0.0f),
+	                                     STPtrGABAb(0.0f, 0.0f));
+	// ---------------- SETUP STATE -------------------
+	sim->setupNetwork();
+	SpikeMonitor* SpkMon = sim->setSpikeMonitor(MEC_LII_Stellate,"DEFAULT");
+	// ---------------- RUN STATE -------------------
+	sim->setExternalCurrent(EC_LI_II_Multipolar_Pyramidal, 100);
+	SpkMon->startRecording();
+	for (int i=0; i<10; i++) {sim->runNetwork(0,100, true);}
+	SpkMon->stopRecording();
+	float firing_rate_1conn = SpkMon->getPopMeanFiringRate();
+	SpkMon->print(false);
+	//printf("firing_rate_1conn:%f\n",firing_rate_1conn);	
+
+	delete sim;
+
+	/* Test 2: Two Synapse Connections */	
+
+	CARLsim* sim2 = new CARLsim("cstp_test_2conn", GPU_MODE, logger, numGPUs, randSeed);
+	EC_LI_II_Multipolar_Pyramidal=sim2->createGroup("EC_LI_II_Multipolar_Pyramidal", 
+	                            1, EXCITATORY_NEURON, ANY, GPU_CORES);  
+	int EC_LI_II_Multipolar_Pyramidal2=sim2->createGroup("EC_LI_II_Multipolar_Pyramidal2", 
+                            	1, EXCITATORY_NEURON, ANY, GPU_CORES);
+	MEC_LII_Stellate=sim2->createGroup("MEC_LII_Stellate", 
+	                            1, EXCITATORY_NEURON, ANY, GPU_CORES);	
+	sim2->setNeuronParameters(EC_LI_II_Multipolar_Pyramidal, 204.0f, 0.0f, 0.37f, 0.0f, -70.53f, 0.0f, -39.99f, 
+	                                0.0f, 0.001f, 0.0f, 0.01f, 0.0f, 3.96f, 0.0f, -54.95f, 0.0f, 
+	                                7.0f, 0.0f, 1);
+	sim2->setNeuronParameters(EC_LI_II_Multipolar_Pyramidal2, 204.0f, 0.0f, 0.37f, 0.0f, -70.53f, 0.0f, -39.99f, 
+	                                0.0f, 0.001f, 0.0f, 0.01f, 0.0f, 3.96f, 0.0f, -54.95f, 0.0f, 
+	                                7.0f, 0.0f, 1);
+	sim2->setNeuronParameters(MEC_LII_Stellate, 118.0f, 0.0f, 0.98f, 0.0f, -58.53f, 0.0f, -43.52f, 
+	                                0.0f, 0.004f, 0.0f, 7.0f, 0.0f, 7.85f, 0.0f, -52.68f, 0.0f, 
+	                                65.0f, 0.0f, 1);
+	// neuron connection parameters 
+	sim2->connect(EC_LI_II_Multipolar_Pyramidal, MEC_LII_Stellate, "one-to-one", 50.0f, 1.0f, 
+	    RangeDelay(1), RadiusRF(-1), SYN_FIXED, 1, 1);
+	sim2->connect(EC_LI_II_Multipolar_Pyramidal2, MEC_LII_Stellate, "one-to-one", 50.0f, 1.0f, 
+	    RangeDelay(1), RadiusRF(-1), SYN_FIXED, 1, 1);
+	sim2->setSTP(EC_LI_II_Multipolar_Pyramidal, MEC_LII_Stellate, true, STPu(0.1513, 0.0f),
+	                                     STPtauU(69.11, 0.0f),
+	                                     STPtauX(98.1, 0.0f),
+	                                     STPtdAMPA(6.0, 0.0f),
+	                                     STPtdNMDA(150.0, 0.0f),
+	                                     STPtdGABAa(5.0, 0.0f),
+	                                     STPtdGABAb(150.0, 0.0f),
+	                                     STPtrNMDA(0.0f, 0.0f),
+	                                     STPtrGABAb(0.0f, 0.0f));
+	sim2->setSTP(EC_LI_II_Multipolar_Pyramidal2, MEC_LII_Stellate, true, STPu(0.1513, 0.0f),
+	                                     STPtauU(69.11, 0.0f),
+	                                     STPtauX(98.1, 0.0f),
+	                                     STPtdAMPA(6.0, 0.0f),
+	                                     STPtdNMDA(150.0, 0.0f),
+	                                     STPtdGABAa(5.0, 0.0f),
+	                                     STPtdGABAb(150.0, 0.0f),
+	                                     STPtrNMDA(0.0f, 0.0f),
+	                                     STPtrGABAb(0.0f, 0.0f));
+	// ---------------- SETUP STATE -------------------
+	sim2->setupNetwork();
+	SpkMon = sim2->setSpikeMonitor(MEC_LII_Stellate,"DEFAULT");
+	// ---------------- RUN STATE -------------------
+	sim2->setExternalCurrent(EC_LI_II_Multipolar_Pyramidal, 100);
+	sim2->setExternalCurrent(EC_LI_II_Multipolar_Pyramidal2, 0);
+	SpkMon->startRecording();
+	for (int i=0; i<10; i++) {sim2->runNetwork(0,100, true);}
+	SpkMon->stopRecording();
+	float firing_rate_2conn = SpkMon->getPopMeanFiringRate();
+	SpkMon->print(false);
+	//printf("firing_rate_2conn:%f\n",firing_rate_2conn);
+
+	delete sim2;
+
+	// Check that firing rate without an additional connection is equal or less than firing rate 
+	// with the connection and 0 external current to the additional connection.
+	EXPECT_LE(firing_rate_1conn, firing_rate_2conn); // ms
+}

--- a/carlsim/testca3/generateCONFIGStateSTP.h
+++ b/carlsim/testca3/generateCONFIGStateSTP.h
@@ -1,0 +1,760 @@
+int CA3_QuadD_LM = sim.createGroup("CA3_QuadD_LM", 328.0,
+                              INHIBITORY_NEURON, 0, BACKEND_CORES);
+                              
+int CA3_Axo_Axonic = sim.createGroup("CA3_Axo_Axonic", 190.0,
+                              INHIBITORY_NEURON, 0, BACKEND_CORES);
+                              
+int CA3_Basket = sim.createGroup("CA3_Basket", 51.0,
+                              INHIBITORY_NEURON, 0, BACKEND_CORES);
+                              
+int CA3_BC_CCK = sim.createGroup("CA3_BC_CCK", 66.0,
+                              INHIBITORY_NEURON, 0, BACKEND_CORES);
+                              
+int CA3_Bistratified = sim.createGroup("CA3_Bistratified", 463.0,
+                              INHIBITORY_NEURON, 0, BACKEND_CORES);
+                              
+int CA3_Ivy = sim.createGroup("CA3_Ivy", 233.0,
+                              INHIBITORY_NEURON, 0, BACKEND_CORES);
+                              
+int CA3_MFA_ORDEN = sim.createGroup("CA3_MFA_ORDEN", 152.0,
+                              INHIBITORY_NEURON, 0, BACKEND_CORES);
+                              
+int CA3_Pyramidal = sim.createGroup("CA3_Pyramidal", 743.0,  // 10000, // 743.0, 74.0,  
+        EXCITATORY_NEURON, 0, BACKEND_CORES);
+                                                   
+
+sim.setNeuronParameters(CA3_QuadD_LM, 186.0, 0.0, 1.77600861583782, 0,
+                                                -73.4821116922868, 0.0, -54.9369058996129, 0.0, 0.00584332072216318,
+                                                0.0, -3.44873648365723, 0.0, 7.06631328236041,
+                                                0.0, -64.4037157222031, 0.0,
+                                                52.0, 0.0, 1);
+
+sim.setNeuronParameters(CA3_Axo_Axonic, 165.0, 0.0, 3.96146287759279, 0,
+                                                -57.099782869594, 0.0, -51.7187562820223, 0.0, 0.00463860807187154,
+                                                0.0, 8.68364493653417, 0.0, 27.7986355932787,
+                                                0.0, -73.9685042125372, 0.0,
+                                                15.0, 0.0, 1);
+                     
+sim.setNeuronParameters(CA3_Basket, 45.0, 0.0, 0.9951729, 0,
+                                                -57.506126, 0.0, -23.378766, 0.0, 0.003846186,
+                                                0.0, 9.2642765, 0.0, 18.454934,
+                                                0.0, -47.555661, 0.0,
+                                                -6.0, 0.0, 1);
+                     
+sim.setNeuronParameters(CA3_BC_CCK, 135.0, 0.0, 0.583005186, 0,
+                                                -58.99667734, 0.0, -39.39832097, 0.0, 0.00574483,
+                                                0.0, -1.244845715, 0.0, 18.27458854,
+                                                0.0, -42.7711851, 0.0,
+                                                54.0, 0.0, 1);
+                     
+sim.setNeuronParameters(CA3_Bistratified, 107.0, 0.0, 3.935030495, 0,
+                                                -64.67262808, 0.0, -58.74397154, 0.0, 0.001952449,
+                                                0.0, 16.57957046, 0.0, -9.928793958,
+                                                0.0, -59.70326258, 0.0,
+                                                19.0, 0.0, 1);
+                     
+sim.setNeuronParameters(CA3_Ivy, 364.0, 0.0, 1.91603822942046, 0,
+                                                -70.4345135750261, 0.0, -40.8589263758355, 0.0, 0.009151158130158,
+                                                0.0, 1.90833702318966, 0.0, -6.91973671560226,
+                                                0.0, -53.3998503336009, 0.0,
+                                                45.0, 0.0, 1);
+                     
+sim.setNeuronParameters(CA3_MFA_ORDEN, 209.0, 0.0, 1.37980713457205, 0,
+                                                -57.076423571379, 0.0, -39.1020427841762, 0.0, 0.00783805979364104,
+                                                0.0, 12.9332855397722, 0.0, 16.3132681887705,
+                                                0.0, -40.6806648852695, 0.0,
+                                                0.0, 0.0, 1);
+                     
+sim.setNeuronParameters(CA3_Pyramidal, 366.0, 0.0, 0.792338703789581, 0,
+                                                -63.2044008171655, 0.0, -33.6041733124267, 0.0, 0.00838350334098279,
+                                                0.0, -42.5524776883928, 0.0, 35.8614648558726,
+                                                0.0, -38.8680990294091, 0.0,
+                                                588.0, 0.0, 1);
+
+
+sim.connect(CA3_QuadD_LM, CA3_Axo_Axonic, "random", RangeWeight(0.0f, 1.3f, 2.3f), 0.00529496670795314f,
+                                          RangeDelay(1), RadiusRF(-1.0), SYN_PLASTIC, 1.473054473f, 0.0f);
+                                       
+sim.connect(CA3_QuadD_LM, CA3_Basket, "random", RangeWeight(0.0f, 0.55f, 1.55f), 0.0667209642727206f,
+                                          RangeDelay(1), RadiusRF(-1.0), SYN_PLASTIC, 1.815288206f, 0.0f);
+                                       
+sim.connect(CA3_QuadD_LM, CA3_BC_CCK, "random", RangeWeight(0.0f, 1.0f, 2.0f), 0.0495724663599669f,
+                                          RangeDelay(1), RadiusRF(-1.0), SYN_PLASTIC, 1.308152788f, 0.0f);
+                                       
+sim.connect(CA3_QuadD_LM, CA3_Pyramidal, "random", RangeWeight(0.0f, 1.45f, 2.45f), 0.11882477878628f,
+                                          RangeDelay(1), RadiusRF(-1.0), SYN_PLASTIC, 1.183249644f, 0.0f);
+                                       
+sim.connect(CA3_Axo_Axonic, CA3_Pyramidal, "random", RangeWeight(0.0f, 1.45f, 2.45f), 0.15f,
+                                          RangeDelay(1), RadiusRF(-1.0), SYN_PLASTIC, 1.869561088f, 0.0f);
+                                       
+sim.connect(CA3_Basket, CA3_QuadD_LM, "random", RangeWeight(0.0f, 0.75f, 1.75f), 0.005f,
+                                          RangeDelay(1), RadiusRF(-1.0), SYN_PLASTIC, 1.750808378f, 0.0f);
+                                       
+sim.connect(CA3_Basket, CA3_Axo_Axonic, "random", RangeWeight(0.0f, 1.3f, 2.3f), 0.025f,
+                                          RangeDelay(1), RadiusRF(-1.0), SYN_PLASTIC, 2.02478806f, 0.0f);
+                                       
+sim.connect(CA3_Basket, CA3_Basket, "random", RangeWeight(0.0f, 0.55f, 1.55f), 0.005f,
+                                          RangeDelay(1), RadiusRF(-1.0), SYN_PLASTIC, 3.281611994f, 0.0f);
+                                       
+sim.connect(CA3_Basket, CA3_BC_CCK, "random", RangeWeight(0.0f, 1.0f, 2.0f), 0.005f,
+                                          RangeDelay(1), RadiusRF(-1.0), SYN_PLASTIC, 1.686238357f, 0.0f);
+                                       
+sim.connect(CA3_Basket, CA3_Bistratified, "random", RangeWeight(0.0f, 1.3f, 2.3f), 0.025f,
+                                          RangeDelay(1), RadiusRF(-1.0), SYN_PLASTIC, 1.770407646f, 0.0f);
+                                       
+sim.connect(CA3_Basket, CA3_MFA_ORDEN, "random", RangeWeight(0.0f, 0.75f, 1.75f), 0.005f,
+                                          RangeDelay(1), RadiusRF(-1.0), SYN_PLASTIC, 1.808726221f, 0.0f);
+                                       
+sim.connect(CA3_Basket, CA3_Pyramidal, "random", RangeWeight(0.0f, 1.45f, 2.45f), 0.15f,
+                                          RangeDelay(1), RadiusRF(-1.0), SYN_PLASTIC, 1.572405696f, 0.0f);
+                                       
+sim.connect(CA3_BC_CCK, CA3_QuadD_LM, "random", RangeWeight(0.0f, 0.75f, 1.75f), 0.025f,
+                                          RangeDelay(1), RadiusRF(-1.0), SYN_PLASTIC, 1.334971075f, 0.0f);
+                                       
+sim.connect(CA3_BC_CCK, CA3_Axo_Axonic, "random", RangeWeight(0.0f, 1.3f, 2.3f), 0.025f,
+                                          RangeDelay(1), RadiusRF(-1.0), SYN_PLASTIC, 1.493830393f, 0.0f);
+                                       
+sim.connect(CA3_BC_CCK, CA3_Basket, "random", RangeWeight(0.0f, 0.55f, 1.55f), 0.005f,
+                                          RangeDelay(1), RadiusRF(-1.0), SYN_PLASTIC, 1.745239175f, 0.0f);
+                                       
+sim.connect(CA3_BC_CCK, CA3_BC_CCK, "random", RangeWeight(0.0f, 1.0f, 2.0f), 0.005f,
+                                          RangeDelay(1), RadiusRF(-1.0), SYN_PLASTIC, 0.965567683f, 0.0f);
+                                       
+sim.connect(CA3_BC_CCK, CA3_Bistratified, "random", RangeWeight(0.0f, 1.3f, 2.3f), 0.025f,
+                                          RangeDelay(1), RadiusRF(-1.0), SYN_PLASTIC, 1.371483576f, 0.0f);
+                                       
+sim.connect(CA3_BC_CCK, CA3_MFA_ORDEN, "random", RangeWeight(0.0f, 0.75f, 1.75f), 0.005f,
+                                          RangeDelay(1), RadiusRF(-1.0), SYN_PLASTIC, 1.355214118f, 0.0f);
+                                       
+sim.connect(CA3_BC_CCK, CA3_Pyramidal, "random", RangeWeight(0.0f, 1.45f, 2.45f), 0.15f,
+                                          RangeDelay(1), RadiusRF(-1.0), SYN_PLASTIC, 1.306303671f, 0.0f);
+                                       
+sim.connect(CA3_Bistratified, CA3_QuadD_LM, "random", RangeWeight(0.0f, 0.75f, 1.75f), 0.00775423637622817f,
+                                          RangeDelay(1), RadiusRF(-1.0), SYN_PLASTIC, 1.490477376f, 0.0f);
+                                       
+sim.connect(CA3_Bistratified, CA3_Axo_Axonic, "random", RangeWeight(0.0f, 1.3f, 2.3f), 0.00659307293350001f,
+                                          RangeDelay(1), RadiusRF(-1.0), SYN_PLASTIC, 1.655173699f, 0.0f);
+                                       
+sim.connect(CA3_Bistratified, CA3_Basket, "random", RangeWeight(0.0f, 0.55f, 1.55f), 0.00926382440444106f,
+                                          RangeDelay(1), RadiusRF(-1.0), SYN_PLASTIC, 1.99431849f, 0.0f);
+                                       
+sim.connect(CA3_Bistratified, CA3_BC_CCK, "random", RangeWeight(0.0f, 1.0f, 2.0f), 0.00431732093529376f,
+                                          RangeDelay(1), RadiusRF(-1.0), SYN_PLASTIC, 1.442647868f, 0.0f);
+                                       
+sim.connect(CA3_Bistratified, CA3_Bistratified, "random", RangeWeight(0.0f, 1.3f, 2.3f), 0.0325785208207766f,
+                                          RangeDelay(1), RadiusRF(-1.0), SYN_PLASTIC, 1.547036443f, 0.0f);
+                                       
+sim.connect(CA3_Bistratified, CA3_Ivy, "random", RangeWeight(0.0f, 0.65f, 1.65f), 0.00385580973430123f,
+                                          RangeDelay(1), RadiusRF(-1.0), SYN_PLASTIC, 2.061179756f, 0.0f);
+                                       
+sim.connect(CA3_Bistratified, CA3_MFA_ORDEN, "random", RangeWeight(0.0f, 1.0f, 2.0f), 0.00862472688778918f,
+                                          RangeDelay(1), RadiusRF(-1.0), SYN_PLASTIC, 1.567727407f, 0.0f);
+                                       
+sim.connect(CA3_Bistratified, CA3_Pyramidal, "random", RangeWeight(0.0f, 1.45f, 2.45f), 0.0278686093547943f,
+                                          RangeDelay(1), RadiusRF(-1.0), SYN_PLASTIC, 1.431148109f, 0.0f);
+                                       
+sim.connect(CA3_Ivy, CA3_QuadD_LM, "random", RangeWeight(0.0f, 0.75f, 1.75f), 0.00198176910683873f,
+                                          RangeDelay(1), RadiusRF(-1.0), SYN_PLASTIC, 1.567261924f, 0.0f);
+                                       
+sim.connect(CA3_Ivy, CA3_Axo_Axonic, "random", RangeWeight(0.0f, 1.3f, 2.3f), 0.00424634524060682f,
+                                          RangeDelay(1), RadiusRF(-1.0), SYN_PLASTIC, 1.758382851f, 0.0f);
+                                       
+sim.connect(CA3_Ivy, CA3_Basket, "random", RangeWeight(0.0f, 0.55f, 1.55f), 0.016300617068683923f,
+                                          RangeDelay(1), RadiusRF(-1.0), SYN_PLASTIC, 2.111359644f, 0.0f);
+                                       
+sim.connect(CA3_Ivy, CA3_BC_CCK, "random", RangeWeight(0.0f, 1.0f, 2.0f), 0.010742278540606838f,
+                                          RangeDelay(1), RadiusRF(-1.0), SYN_PLASTIC, 1.54009769f, 0.0f);
+                                       
+sim.connect(CA3_Ivy, CA3_Bistratified, "random", RangeWeight(0.0f, 1.3f, 2.3f), 0.01703156100118382f,
+                                          RangeDelay(1), RadiusRF(-1.0), SYN_PLASTIC, 1.660111909f, 0.0f);
+                                       
+sim.connect(CA3_Ivy, CA3_Ivy, "random", RangeWeight(0.0f, 0.65f, 1.65f), 0.00375271870052702f,
+                                          RangeDelay(1), RadiusRF(-1.0), SYN_PLASTIC, 2.142741525f, 0.0f);
+                                       
+sim.connect(CA3_Ivy, CA3_MFA_ORDEN, "random", RangeWeight(0.0f, 0.75f, 1.75f), 0.0169285421706311f,
+                                          RangeDelay(1), RadiusRF(-1.0), SYN_PLASTIC, 1.687214907f, 0.0f);
+                                       
+sim.connect(CA3_Ivy, CA3_Pyramidal, "random", RangeWeight(0.0f, 1.45f, 2.45f), 0.0720967942651253f,
+                                          RangeDelay(1), RadiusRF(-1.0), SYN_PLASTIC, 1.540661646f, 0.0f);
+                                       
+sim.connect(CA3_MFA_ORDEN, CA3_QuadD_LM, "random", RangeWeight(0.0f, 0.75f, 1.75f), 0.00375566003798539f,
+                                          RangeDelay(1), RadiusRF(-1.0), SYN_PLASTIC, 1.471995564f, 0.0f);
+                                       
+sim.connect(CA3_MFA_ORDEN, CA3_Axo_Axonic, "random", RangeWeight(0.0f, 1.3f, 2.3f), 0.00437941786544469f,
+                                          RangeDelay(1), RadiusRF(-1.0), SYN_PLASTIC, 1.628518636f, 0.0f);
+                                       
+sim.connect(CA3_MFA_ORDEN, CA3_Basket, "random", RangeWeight(0.0f, 0.55f, 1.55f), 0.0072882240621001f,
+                                          RangeDelay(1), RadiusRF(-1.0), SYN_PLASTIC, 1.972333716f, 0.0f);
+                                       
+sim.connect(CA3_MFA_ORDEN, CA3_BC_CCK, "random", RangeWeight(0.0f, 1.0f, 2.0f), 0.00526662735486614f,
+                                          RangeDelay(1), RadiusRF(-1.0), SYN_PLASTIC, 1.415044453f, 0.0f);
+                                       
+sim.connect(CA3_MFA_ORDEN, CA3_Bistratified, "random", RangeWeight(0.0f, 1.3f, 2.3f), 0.00480204193183194f,
+                                          RangeDelay(1), RadiusRF(-1.0), SYN_PLASTIC, 1.536494845f, 0.0f);
+                                       
+sim.connect(CA3_MFA_ORDEN, CA3_Ivy, "random", RangeWeight(0.0f, 0.65f, 1.65f), 0.00267981747242981f,
+                                          RangeDelay(1), RadiusRF(-1.0), SYN_PLASTIC, 2.081976802f, 0.0f);
+                                       
+sim.connect(CA3_MFA_ORDEN, CA3_MFA_ORDEN, "random", RangeWeight(0.0f, 0.75f, 1.75f), 0.00210548528014741f,
+                                          RangeDelay(1), RadiusRF(-1.0), SYN_PLASTIC, 1.552656079f, 0.0f);
+                                       
+sim.connect(CA3_MFA_ORDEN, CA3_Pyramidal, "random", RangeWeight(0.0f, 1.45f, 2.45f), 0.0417555599977689f,
+                                          RangeDelay(1), RadiusRF(-1.0), SYN_PLASTIC, 1.360315289f, 0.0f);
+
+sim.connect(CA3_Pyramidal, CA3_QuadD_LM, "random", RangeWeight(0.0f, 1.25f, 2.25f), 0.0133672243607345f,
+                                      RangeDelay(1,2), RadiusRF(-1.0), SYN_PLASTIC, 0.874424964f, 0.0f);
+                                   
+sim.connect(CA3_Pyramidal, CA3_Axo_Axonic, "random", RangeWeight(0.0f, 0.7f, 1.7f), 0.0148205394733136f,
+                                      RangeDelay(1,2), RadiusRF(-1.0), SYN_PLASTIC, 0.932621138f, 0.0f);
+                                   
+sim.connect(CA3_Pyramidal, CA3_Basket, "random", RangeWeight(0.0f, 1.45f, 2.45f), 0.0197417562762975f,
+                                      RangeDelay(1,2), RadiusRF(-1.0), SYN_PLASTIC, 1.172460639f, 0.0f);
+                                   
+sim.connect(CA3_Pyramidal, CA3_BC_CCK, "random", RangeWeight(0.0f, 1.0f, 2.0f), 0.0172994236281402f,
+                                      RangeDelay(1,2), RadiusRF(-1.0), SYN_PLASTIC, 0.847532877f, 0.0f);
+                                   
+sim.connect(CA3_Pyramidal, CA3_Bistratified, "random", RangeWeight(0.0f, 0.7f, 1.7f), 0.015857085924813f,
+                                      RangeDelay(1,2), RadiusRF(-1.0), SYN_PLASTIC, 0.883682094f, 0.0f);
+                                   
+sim.connect(CA3_Pyramidal, CA3_Ivy, "random", RangeWeight(0.0f, 1.35f, 2.35f), 0.0251567907913944f,
+                                      RangeDelay(1,2), RadiusRF(-1.0), SYN_PLASTIC, 1.314331038f, 0.0f);
+                                   
+sim.connect(CA3_Pyramidal, CA3_MFA_ORDEN, "random", RangeWeight(0.0f, 1.25f, 2.25f), 0.0209934225689348f,
+                                      RangeDelay(1,2), RadiusRF(-1.0), SYN_PLASTIC, 0.88025265f, 0.0f);
+                                   
+sim.connect(CA3_Pyramidal, CA3_Pyramidal, "random", RangeWeight(0.0f, 0.55f, 1.55f), 0.0250664662231983f,
+                                      RangeDelay(1,2), RadiusRF(-1.0), SYN_PLASTIC, 0.553062478f, 0.0f);
+                                   
+sim.setSTP(CA3_QuadD_LM, CA3_Axo_Axonic, true, STPu(0.152487328f, 0.0f),
+                                         STPtauU(22.34022321f, 0.0f),
+                                         STPtauX(635.0122846f, 0.0f),
+                                         STPtdAMPA(5.0f, 0.0f),
+                                         STPtdNMDA(150.0f, 0.0f),
+                                         STPtdGABAa(5.168513359f, 0.0f),
+                                         STPtdGABAb(150.0f, 0.0f),
+                                         STPtrNMDA(0.0f, 0.0f),
+                                         STPtrGABAb(0.0f, 0.0f));
+
+sim.setSTP(CA3_QuadD_LM, CA3_Basket, true, STPu(0.3362564094f, 0.0f),
+                                         STPtauU(16.42005923f, 0.0f),
+                                         STPtauX(663.2470985f, 0.0f),
+                                         STPtdAMPA(5.0f, 0.0f),
+                                         STPtdNMDA(150.0f, 0.0f),
+                                         STPtdGABAa(4.293130764f, 0.0f),
+                                         STPtdGABAb(150.0f, 0.0f),
+                                         STPtrNMDA(0.0f, 0.0f),
+                                         STPtrGABAb(0.0f, 0.0f));
+                                     
+sim.setSTP(CA3_QuadD_LM, CA3_BC_CCK, true, STPu(0.207810376f, 0.0f),
+                                         STPtauU(17.78433468f, 0.0f),
+                                         STPtauX(596.5048064f, 0.0f),
+                                         STPtdAMPA(5.0f, 0.0f),
+                                         STPtdNMDA(150.0f, 0.0f),
+                                         STPtdGABAa(4.830825741f, 0.0f),
+                                         STPtdGABAb(150.0f, 0.0f),
+                                         STPtrNMDA(0.0f, 0.0f),
+                                         STPtrGABAb(0.0f, 0.0f));
+                                     
+sim.setSTP(CA3_QuadD_LM, CA3_Pyramidal, true, STPu(0.10647895115000001f, 0.0f),
+                                         STPtauU(24.78801373f, 0.0f),
+                                         STPtauX(382.1372881f, 0.0f),
+                                         STPtdAMPA(5.0f, 0.0f),
+                                         STPtdNMDA(150.0f, 0.0f),
+                                         STPtdGABAa(9.107305544f, 0.0f),
+                                         STPtdGABAb(150.0f, 0.0f),
+                                         STPtrNMDA(0.0f, 0.0f),
+                                         STPtrGABAb(0.0f, 0.0f));
+                                     
+sim.setSTP(CA3_Axo_Axonic, CA3_Pyramidal, true, STPu(0.1302436377f, 0.0f),
+                                         STPtauU(12.93029701f, 0.0f),
+                                         STPtauX(361.0287219f, 0.0f),
+                                         STPtdAMPA(5.0f, 0.0f),
+                                         STPtdNMDA(150.0f, 0.0f),
+                                         STPtdGABAa(7.623472774f, 0.0f),
+                                         STPtdGABAb(150.0f, 0.0f),
+                                         STPtrNMDA(0.0f, 0.0f),
+                                         STPtrGABAb(0.0f, 0.0f));
+                                     
+sim.setSTP(CA3_Basket, CA3_QuadD_LM, true, STPu(0.30675536625f, 0.0f),
+                                         STPtauU(19.30519205f, 0.0f),
+                                         STPtauX(589.2002267f, 0.0f),
+                                         STPtdAMPA(5.0f, 0.0f),
+                                         STPtdNMDA(150.0f, 0.0f),
+                                         STPtdGABAa(5.162447367f, 0.0f),
+                                         STPtdGABAb(150.0f, 0.0f),
+                                         STPtrNMDA(0.0f, 0.0f),
+                                         STPtrGABAb(0.0f, 0.0f));
+                                     
+sim.setSTP(CA3_Basket, CA3_Axo_Axonic, true, STPu(0.1910149885f, 0.0f),
+                                         STPtauU(23.20689302f, 0.0f),
+                                         STPtauX(725.0291555f, 0.0f),
+                                         STPtdAMPA(5.0f, 0.0f),
+                                         STPtdNMDA(150.0f, 0.0f),
+                                         STPtdGABAa(3.800283876f, 0.0f),
+                                         STPtdGABAb(150.0f, 0.0f),
+                                         STPtrNMDA(0.0f, 0.0f),
+                                         STPtrGABAb(0.0f, 0.0f));
+                                     
+sim.setSTP(CA3_Basket, CA3_Basket, true, STPu(0.38950627465000004f, 0.0f),
+                                         STPtauU(11.19042564f, 0.0f),
+                                         STPtauX(689.5059466f, 0.0f),
+                                         STPtdAMPA(5.0f, 0.0f),
+                                         STPtdNMDA(150.0f, 0.0f),
+                                         STPtdGABAa(3.007016545f, 0.0f),
+                                         STPtdGABAb(150.0f, 0.0f),
+                                         STPtrNMDA(0.0f, 0.0f),
+                                         STPtrGABAb(0.0f, 0.0f));
+                                     
+sim.setSTP(CA3_Basket, CA3_BC_CCK, true, STPu(0.235943711f, 0.0f),
+                                         STPtauU(16.71506093f, 0.0f),
+                                         STPtauX(636.7647263f, 0.0f),
+                                         STPtdAMPA(5.0f, 0.0f),
+                                         STPtdNMDA(150.0f, 0.0f),
+                                         STPtdGABAa(4.20676528f, 0.0f),
+                                         STPtdGABAb(150.0f, 0.0f),
+                                         STPtrNMDA(0.0f, 0.0f),
+                                         STPtrGABAb(0.0f, 0.0f));
+                                     
+sim.setSTP(CA3_Basket, CA3_Bistratified, true, STPu(0.1754364731f, 0.0f),
+                                         STPtauU(16.7158668f, 0.0f),
+                                         STPtauX(680.3279514f, 0.0f),
+                                         STPtdAMPA(5.0f, 0.0f),
+                                         STPtdNMDA(150.0f, 0.0f),
+                                         STPtdGABAa(4.720497985f, 0.0f),
+                                         STPtdGABAb(150.0f, 0.0f),
+                                         STPtrNMDA(0.0f, 0.0f),
+                                         STPtrGABAb(0.0f, 0.0f));
+                                     
+sim.setSTP(CA3_Basket, CA3_MFA_ORDEN, true, STPu(0.301856475f, 0.0f),
+                                         STPtauU(19.60369075f, 0.0f),
+                                         STPtauX(581.9355018f, 0.0f),
+                                         STPtdAMPA(5.0f, 0.0f),
+                                         STPtdNMDA(150.0f, 0.0f),
+                                         STPtdGABAa(5.230610278f, 0.0f),
+                                         STPtdGABAb(150.0f, 0.0f),
+                                         STPtrNMDA(0.0f, 0.0f),
+                                         STPtrGABAb(0.0f, 0.0f));
+                                     
+sim.setSTP(CA3_Basket, CA3_Pyramidal, true, STPu(0.12521945645000002f, 0.0f),
+                                         STPtauU(16.73589406f, 0.0f),
+                                         STPtauX(384.3363321f, 0.0f),
+                                         STPtdAMPA(5.0f, 0.0f),
+                                         STPtdNMDA(150.0f, 0.0f),
+                                         STPtdGABAa(7.63862234f, 0.0f),
+                                         STPtdGABAb(150.0f, 0.0f),
+                                         STPtrNMDA(0.0f, 0.0f),
+                                         STPtrGABAb(0.0f, 0.0f));
+                                     
+sim.setSTP(CA3_BC_CCK, CA3_QuadD_LM, true, STPu(0.21874558374999997f, 0.0f),
+                                         STPtauU(17.34307333f, 0.0f),
+                                         STPtauX(398.1521614f, 0.0f),
+                                         STPtdAMPA(5.0f, 0.0f),
+                                         STPtdNMDA(150.0f, 0.0f),
+                                         STPtdGABAa(6.480095841f, 0.0f),
+                                         STPtdGABAb(150.0f, 0.0f),
+                                         STPtrNMDA(0.0f, 0.0f),
+                                         STPtrGABAb(0.0f, 0.0f));
+                                     
+sim.setSTP(CA3_BC_CCK, CA3_Axo_Axonic, true, STPu(0.12352907559999998f, 0.0f),
+                                         STPtauU(18.502335f, 0.0f),
+                                         STPtauX(477.4286298f, 0.0f),
+                                         STPtdAMPA(5.0f, 0.0f),
+                                         STPtdNMDA(150.0f, 0.0f),
+                                         STPtdGABAa(5.43847192f, 0.0f),
+                                         STPtdGABAb(150.0f, 0.0f),
+                                         STPtrNMDA(0.0f, 0.0f),
+                                         STPtrGABAb(0.0f, 0.0f));
+                                     
+sim.setSTP(CA3_BC_CCK, CA3_Basket, true, STPu(0.28360436175000003f, 0.0f),
+                                         STPtauU(14.85568316f, 0.0f),
+                                         STPtauX(505.1237763f, 0.0f),
+                                         STPtdAMPA(5.0f, 0.0f),
+                                         STPtdNMDA(150.0f, 0.0f),
+                                         STPtdGABAa(4.688537876f, 0.0f),
+                                         STPtdGABAb(150.0f, 0.0f),
+                                         STPtrNMDA(0.0f, 0.0f),
+                                         STPtrGABAb(0.0f, 0.0f));
+                                     
+sim.setSTP(CA3_BC_CCK, CA3_BC_CCK, true, STPu(0.118630661f, 0.0f),
+                                         STPtauU(23.37589368f, 0.0f),
+                                         STPtauX(283.28138f, 0.0f),
+                                         STPtdAMPA(5.0f, 0.0f),
+                                         STPtdNMDA(150.0f, 0.0f),
+                                         STPtdGABAa(4.886667725f, 0.0f),
+                                         STPtdGABAb(150.0f, 0.0f),
+                                         STPtrNMDA(0.0f, 0.0f),
+                                         STPtrGABAb(0.0f, 0.0f));
+                                     
+sim.setSTP(CA3_BC_CCK, CA3_Bistratified, true, STPu(0.1260104916f, 0.0f),
+                                         STPtauU(15.24644944f, 0.0f),
+                                         STPtauX(478.3138872f, 0.0f),
+                                         STPtdAMPA(5.0f, 0.0f),
+                                         STPtdNMDA(150.0f, 0.0f),
+                                         STPtdGABAa(5.9732847f, 0.0f),
+                                         STPtdGABAb(150.0f, 0.0f),
+                                         STPtrNMDA(0.0f, 0.0f),
+                                         STPtrGABAb(0.0f, 0.0f));
+                                     
+sim.setSTP(CA3_BC_CCK, CA3_MFA_ORDEN, true, STPu(0.21055725f, 0.0f),
+                                         STPtauU(17.83862927f, 0.0f),
+                                         STPtauX(421.419837f, 0.0f),
+                                         STPtdAMPA(5.0f, 0.0f),
+                                         STPtdNMDA(150.0f, 0.0f),
+                                         STPtdGABAa(6.538700998f, 0.0f),
+                                         STPtdGABAb(150.0f, 0.0f),
+                                         STPtrNMDA(0.0f, 0.0f),
+                                         STPtrGABAb(0.0f, 0.0f));
+                                     
+sim.setSTP(CA3_BC_CCK, CA3_Pyramidal, true, STPu(0.08024396655f, 0.0f),
+                                         STPtauU(13.7603965f, 0.0f),
+                                         STPtauX(376.8743946f, 0.0f),
+                                         STPtdAMPA(5.0f, 0.0f),
+                                         STPtdNMDA(150.0f, 0.0f),
+                                         STPtdGABAa(9.101015633f, 0.0f),
+                                         STPtdGABAb(150.0f, 0.0f),
+                                         STPtrNMDA(0.0f, 0.0f),
+                                         STPtrGABAb(0.0f, 0.0f));
+                                     
+sim.setSTP(CA3_Bistratified, CA3_QuadD_LM, true, STPu(0.2952313625f, 0.0f),
+                                         STPtauU(17.89475495f, 0.0f),
+                                         STPtauX(594.3278762f, 0.0f),
+                                         STPtdAMPA(5.0f, 0.0f),
+                                         STPtdNMDA(150.0f, 0.0f),
+                                         STPtdGABAa(5.529521921f, 0.0f),
+                                         STPtdGABAb(150.0f, 0.0f),
+                                         STPtrNMDA(0.0f, 0.0f),
+                                         STPtrGABAb(0.0f, 0.0f));
+                                     
+sim.setSTP(CA3_Bistratified, CA3_Axo_Axonic, true, STPu(0.16745713739999998f, 0.0f),
+                                         STPtauU(19.16221108f, 0.0f),
+                                         STPtauX(686.2791734f, 0.0f),
+                                         STPtdAMPA(5.0f, 0.0f),
+                                         STPtdNMDA(150.0f, 0.0f),
+                                         STPtdGABAa(4.568545011f, 0.0f),
+                                         STPtdGABAb(150.0f, 0.0f),
+                                         STPtrNMDA(0.0f, 0.0f),
+                                         STPtrGABAb(0.0f, 0.0f));
+                                     
+sim.setSTP(CA3_Bistratified, CA3_Basket, true, STPu(0.36559896319999996f, 0.0f),
+                                         STPtauU(14.59835713f, 0.0f),
+                                         STPtauX(695.2132647f, 0.0f),
+                                         STPtdAMPA(5.0f, 0.0f),
+                                         STPtdNMDA(150.0f, 0.0f),
+                                         STPtdGABAa(3.857230209f, 0.0f),
+                                         STPtdGABAb(150.0f, 0.0f),
+                                         STPtrNMDA(0.0f, 0.0f),
+                                         STPtrGABAb(0.0f, 0.0f));
+                                     
+sim.setSTP(CA3_Bistratified, CA3_BC_CCK, true, STPu(0.221085653f, 0.0f),
+                                         STPtauU(17.68670462f, 0.0f),
+                                         STPtauX(592.1864649f, 0.0f),
+                                         STPtdAMPA(5.0f, 0.0f),
+                                         STPtdNMDA(150.0f, 0.0f),
+                                         STPtdGABAa(4.577797723f, 0.0f),
+                                         STPtdGABAb(150.0f, 0.0f),
+                                         STPtrNMDA(0.0f, 0.0f),
+                                         STPtrGABAb(0.0f, 0.0f));
+                                     
+sim.setSTP(CA3_Bistratified, CA3_Bistratified, true, STPu(0.1728205871f, 0.0f),
+                                         STPtauU(13.59791022f, 0.0f),
+                                         STPtauX(775.0419417f, 0.0f),
+                                         STPtdAMPA(5.0f, 0.0f),
+                                         STPtdNMDA(150.0f, 0.0f),
+                                         STPtdGABAa(4.576515291f, 0.0f),
+                                         STPtdGABAb(150.0f, 0.0f),
+                                         STPtrNMDA(0.0f, 0.0f),
+                                         STPtrGABAb(0.0f, 0.0f));
+                                     
+sim.setSTP(CA3_Bistratified, CA3_Ivy, true, STPu(0.30417893415f, 0.0f),
+                                         STPtauU(13.54144463f, 0.0f),
+                                         STPtauX(706.9023888f, 0.0f),
+                                         STPtdAMPA(5.0f, 0.0f),
+                                         STPtdNMDA(150.0f, 0.0f),
+                                         STPtdGABAa(4.380229451f, 0.0f),
+                                         STPtdGABAb(150.0f, 0.0f),
+                                         STPtrNMDA(0.0f, 0.0f),
+                                         STPtrGABAb(0.0f, 0.0f));
+                                     
+sim.setSTP(CA3_Bistratified, CA3_MFA_ORDEN, true, STPu(0.29119507624999996f, 0.0f),
+                                         STPtauU(18.29762673f, 0.0f),
+                                         STPtauX(605.2466713f, 0.0f),
+                                         STPtdAMPA(5.0f, 0.0f),
+                                         STPtdNMDA(150.0f, 0.0f),
+                                         STPtdGABAa(5.537380416f, 0.0f),
+                                         STPtdGABAb(150.0f, 0.0f),
+                                         STPtrNMDA(0.0f, 0.0f),
+                                         STPtrGABAb(0.0f, 0.0f));
+                                     
+sim.setSTP(CA3_Bistratified, CA3_Pyramidal, true, STPu(0.11725808215000001f, 0.0f),
+                                         STPtauU(16.60665423f, 0.0f),
+                                         STPtauX(481.8508503f, 0.0f),
+                                         STPtdAMPA(5.0f, 0.0f),
+                                         STPtdNMDA(150.0f, 0.0f),
+                                         STPtdGABAa(7.48628716f, 0.0f),
+                                         STPtdGABAb(150.0f, 0.0f),
+                                         STPtrNMDA(0.0f, 0.0f),
+                                         STPtrGABAb(0.0f, 0.0f));
+                                     
+sim.setSTP(CA3_Ivy, CA3_QuadD_LM, true, STPu(0.2988703625f, 0.0f),
+                                         STPtauU(26.14661454f, 0.0f),
+                                         STPtauX(563.468709f, 0.0f),
+                                         STPtdAMPA(5.0f, 0.0f),
+                                         STPtdNMDA(150.0f, 0.0f),
+                                         STPtdGABAa(6.894190356f, 0.0f),
+                                         STPtdGABAb(150.0f, 0.0f),
+                                         STPtrNMDA(0.0f, 0.0f),
+                                         STPtrGABAb(0.0f, 0.0f));
+                                     
+sim.setSTP(CA3_Ivy, CA3_Axo_Axonic, true, STPu(0.17126417349999998f, 0.0f),
+                                         STPtauU(25.51127047f, 0.0f),
+                                         STPtauX(651.6350355f, 0.0f),
+                                         STPtdAMPA(5.0f, 0.0f),
+                                         STPtdNMDA(150.0f, 0.0f),
+                                         STPtdGABAa(5.673753656f, 0.0f),
+                                         STPtdGABAb(150.0f, 0.0f),
+                                         STPtrNMDA(0.0f, 0.0f),
+                                         STPtrGABAb(0.0f, 0.0f));
+                                     
+sim.setSTP(CA3_Ivy, CA3_Basket, true, STPu(0.37004219675f, 0.0f),
+                                         STPtauU(19.12313634f, 0.0f),
+                                         STPtauX(665.1591417f, 0.0f),
+                                         STPtdAMPA(5.0f, 0.0f),
+                                         STPtdNMDA(150.0f, 0.0f),
+                                         STPtdGABAa(4.745602473f, 0.0f),
+                                         STPtdGABAb(150.0f, 0.0f),
+                                         STPtrNMDA(0.0f, 0.0f),
+                                         STPtrGABAb(0.0f, 0.0f));
+                                     
+sim.setSTP(CA3_Ivy, CA3_BC_CCK, true, STPu(0.229677262f, 0.0f),
+                                         STPtauU(20.97804705f, 0.0f),
+                                         STPtauX(614.0072327f, 0.0f),
+                                         STPtdAMPA(5.0f, 0.0f),
+                                         STPtdNMDA(150.0f, 0.0f),
+                                         STPtdGABAa(5.398921413f, 0.0f),
+                                         STPtdGABAb(150.0f, 0.0f),
+                                         STPtrNMDA(0.0f, 0.0f),
+                                         STPtrGABAb(0.0f, 0.0f));
+                                     
+sim.setSTP(CA3_Ivy, CA3_Bistratified, true, STPu(0.1722673449f, 0.0f),
+                                         STPtauU(22.68666918f, 0.0f),
+                                         STPtauX(660.479446f, 0.0f),
+                                         STPtdAMPA(5.0f, 0.0f),
+                                         STPtdNMDA(150.0f, 0.0f),
+                                         STPtdGABAa(6.240503496f, 0.0f),
+                                         STPtdGABAb(150.0f, 0.0f),
+                                         STPtrNMDA(0.0f, 0.0f),
+                                         STPtrGABAb(0.0f, 0.0f));
+                                     
+sim.setSTP(CA3_Ivy, CA3_Ivy, true, STPu(0.3132958986f, 0.0f),
+                                         STPtauU(17.71732982f, 0.0f),
+                                         STPtauX(675.5443943f, 0.0f),
+                                         STPtdAMPA(5.0f, 0.0f),
+                                         STPtdNMDA(150.0f, 0.0f),
+                                         STPtdGABAa(5.513908651f, 0.0f),
+                                         STPtdGABAb(150.0f, 0.0f),
+                                         STPtrNMDA(0.0f, 0.0f),
+                                         STPtrGABAb(0.0f, 0.0f));
+                                     
+sim.setSTP(CA3_Ivy, CA3_MFA_ORDEN, true, STPu(0.29543340500000004f, 0.0f),
+                                         STPtauU(28.44917201f, 0.0f),
+                                         STPtauX(578.8951805f, 0.0f),
+                                         STPtdAMPA(5.0f, 0.0f),
+                                         STPtdNMDA(150.0f, 0.0f),
+                                         STPtdGABAa(6.961017332f, 0.0f),
+                                         STPtdGABAb(150.0f, 0.0f),
+                                         STPtrNMDA(0.0f, 0.0f),
+                                         STPtrGABAb(0.0f, 0.0f));
+                                     
+sim.setSTP(CA3_Ivy, CA3_Pyramidal, true, STPu(0.12075829095000001f, 0.0f),
+                                         STPtauU(23.01118394f, 0.0f),
+                                         STPtauX(439.5040963f, 0.0f),
+                                         STPtdAMPA(5.0f, 0.0f),
+                                         STPtdNMDA(150.0f, 0.0f),
+                                         STPtdGABAa(9.007078916f, 0.0f),
+                                         STPtdGABAb(150.0f, 0.0f),
+                                         STPtrNMDA(0.0f, 0.0f),
+                                         STPtrGABAb(0.0f, 0.0f));
+                                     
+sim.setSTP(CA3_MFA_ORDEN, CA3_QuadD_LM, true, STPu(0.28953853f, 0.0f),
+                                         STPtauU(21.00936153f, 0.0f),
+                                         STPtauX(637.949947f, 0.0f),
+                                         STPtdAMPA(5.0f, 0.0f),
+                                         STPtdNMDA(150.0f, 0.0f),
+                                         STPtdGABAa(5.517195135f, 0.0f),
+                                         STPtdGABAb(150.0f, 0.0f),
+                                         STPtrNMDA(0.0f, 0.0f),
+                                         STPtrGABAb(0.0f, 0.0f));
+                                     
+sim.setSTP(CA3_MFA_ORDEN, CA3_Axo_Axonic, true, STPu(0.1647654253f, 0.0f),
+                                         STPtauU(21.44649708f, 0.0f),
+                                         STPtauX(762.6005365f, 0.0f),
+                                         STPtdAMPA(5.0f, 0.0f),
+                                         STPtdNMDA(150.0f, 0.0f),
+                                         STPtdGABAa(4.549658496f, 0.0f),
+                                         STPtdGABAb(150.0f, 0.0f),
+                                         STPtrNMDA(0.0f, 0.0f),
+                                         STPtrGABAb(0.0f, 0.0f));
+                                     
+sim.setSTP(CA3_MFA_ORDEN, CA3_Basket, true, STPu(0.36184299919999996f, 0.0f),
+                                         STPtauU(15.70448009f, 0.0f),
+                                         STPtauX(759.1190877f, 0.0f),
+                                         STPtdAMPA(5.0f, 0.0f),
+                                         STPtdNMDA(150.0f, 0.0f),
+                                         STPtdGABAa(3.896195604f, 0.0f),
+                                         STPtdGABAb(150.0f, 0.0f),
+                                         STPtrNMDA(0.0f, 0.0f),
+                                         STPtrGABAb(0.0f, 0.0f));
+                                     
+sim.setSTP(CA3_MFA_ORDEN, CA3_BC_CCK, true, STPu(0.22096495f, 0.0f),
+                                         STPtauU(17.0758504f, 0.0f),
+                                         STPtauX(693.9231434f, 0.0f),
+                                         STPtdAMPA(5.0f, 0.0f),
+                                         STPtdNMDA(150.0f, 0.0f),
+                                         STPtdGABAa(4.322167425f, 0.0f),
+                                         STPtdGABAb(150.0f, 0.0f),
+                                         STPtrNMDA(0.0f, 0.0f),
+                                         STPtrGABAb(0.0f, 0.0f));
+                                     
+sim.setSTP(CA3_MFA_ORDEN, CA3_Bistratified, true, STPu(0.1684026827f, 0.0f),
+                                         STPtauU(17.26898777f, 0.0f),
+                                         STPtauX(776.5689731f, 0.0f),
+                                         STPtdAMPA(5.0f, 0.0f),
+                                         STPtdNMDA(150.0f, 0.0f),
+                                         STPtdGABAa(4.958324186f, 0.0f),
+                                         STPtdGABAb(150.0f, 0.0f),
+                                         STPtrNMDA(0.0f, 0.0f),
+                                         STPtrGABAb(0.0f, 0.0f));
+                                     
+sim.setSTP(CA3_MFA_ORDEN, CA3_Ivy, true, STPu(0.29727356805000005f, 0.0f),
+                                         STPtauU(13.87512648f, 0.0f),
+                                         STPtauX(806.4750758f, 0.0f),
+                                         STPtdAMPA(5.0f, 0.0f),
+                                         STPtdNMDA(150.0f, 0.0f),
+                                         STPtdGABAa(4.317088488f, 0.0f),
+                                         STPtdGABAb(150.0f, 0.0f),
+                                         STPtrNMDA(0.0f, 0.0f),
+                                         STPtrGABAb(0.0f, 0.0f));
+                                     
+sim.setSTP(CA3_MFA_ORDEN, CA3_MFA_ORDEN, true, STPu(0.2855712375f, 0.0f),
+                                         STPtauU(22.52027885f, 0.0f),
+                                         STPtauX(642.0975453f, 0.0f),
+                                         STPtdAMPA(5.0f, 0.0f),
+                                         STPtdNMDA(150.0f, 0.0f),
+                                         STPtdGABAa(5.533747322f, 0.0f),
+                                         STPtdGABAb(150.0f, 0.0f),
+                                         STPtrNMDA(0.0f, 0.0f),
+                                         STPtrGABAb(0.0f, 0.0f));
+                                     
+sim.setSTP(CA3_MFA_ORDEN, CA3_Pyramidal, true, STPu(0.11893441670000002f, 0.0f),
+                                         STPtauU(20.61711347f, 0.0f),
+                                         STPtauX(496.0484093f, 0.0f),
+                                         STPtdAMPA(5.0f, 0.0f),
+                                         STPtdNMDA(150.0f, 0.0f),
+                                         STPtdGABAa(7.149050278f, 0.0f),
+                                         STPtdGABAb(150.0f, 0.0f),
+                                         STPtrNMDA(0.0f, 0.0f),
+                                         STPtrGABAb(0.0f, 0.0f));
+                                     
+sim.setSTP(CA3_Pyramidal, CA3_QuadD_LM, true, STPu(0.14977632825f, 0.0f),
+                                     STPtauU(27.15856439f, 0.0f),
+                                     STPtauX(453.2939139f, 0.0f),
+                                     STPtdAMPA(5.815770593f, 0.0f),
+                                     STPtdNMDA(150.0f, 0.0f),
+                                     STPtdGABAa(6.0f, 0.0f),
+                                     STPtdGABAb(150.0f, 0.0f),
+                                     STPtrNMDA(0.0f, 0.0f),
+                                     STPtrGABAb(0.0f, 0.0f));
+                                 
+sim.setSTP(CA3_Pyramidal, CA3_Axo_Axonic, true, STPu(0.2564127943f, 0.0f),
+                                     STPtauU(26.26018349f, 0.0f),
+                                     STPtauX(630.7258001f, 0.0f),
+                                     STPtdAMPA(4.92302074f, 0.0f),
+                                     STPtdNMDA(150.0f, 0.0f),
+                                     STPtdGABAa(6.0f, 0.0f),
+                                     STPtdGABAb(150.0f, 0.0f),
+                                     STPtrNMDA(0.0f, 0.0f),
+                                     STPtrGABAb(0.0f, 0.0f));
+                                 
+sim.setSTP(CA3_Pyramidal, CA3_Basket, true, STPu(0.12174287290000001f, 0.0f),
+                                     STPtauU(21.16086172f, 0.0f),
+                                     STPtauX(691.4177768f, 0.0f),
+                                     STPtdAMPA(3.97130389f, 0.0f),
+                                     STPtdNMDA(150.0f, 0.0f),
+                                     STPtdGABAa(6.0f, 0.0f),
+                                     STPtdGABAb(150.0f, 0.0f),
+                                     STPtrNMDA(0.0f, 0.0f),
+                                     STPtrGABAb(0.0f, 0.0f));
+                                 
+sim.setSTP(CA3_Pyramidal, CA3_BC_CCK, true, STPu(0.204890451f, 0.0f),
+                                     STPtauU(22.45458108f, 0.0f),
+                                     STPtauX(530.4003851f, 0.0f),
+                                     STPtdAMPA(4.2935729f, 0.0f),
+                                     STPtdNMDA(150.0f, 0.0f),
+                                     STPtdGABAa(6.0f, 0.0f),
+                                     STPtdGABAb(150.0f, 0.0f),
+                                     STPtrNMDA(0.0f, 0.0f),
+                                     STPtrGABAb(0.0f, 0.0f));
+                                 
+sim.setSTP(CA3_Pyramidal, CA3_Bistratified, true, STPu(0.2646923734f, 0.0f),
+                                     STPtauU(23.85082513f, 0.0f),
+                                     STPtauX(569.1504567f, 0.0f),
+                                     STPtdAMPA(5.367704956f, 0.0f),
+                                     STPtdNMDA(150.0f, 0.0f),
+                                     STPtdGABAa(6.0f, 0.0f),
+                                     STPtdGABAb(150.0f, 0.0f),
+                                     STPtrNMDA(0.0f, 0.0f),
+                                     STPtrGABAb(0.0f, 0.0f));
+                                 
+sim.setSTP(CA3_Pyramidal, CA3_Ivy, true, STPu(0.1246890164f, 0.0f),
+                                     STPtauU(18.84783629f, 0.0f),
+                                     STPtauX(623.453684f, 0.0f),
+                                     STPtdAMPA(4.481241177f, 0.0f),
+                                     STPtdNMDA(150.0f, 0.0f),
+                                     STPtdGABAa(6.0f, 0.0f),
+                                     STPtdGABAb(150.0f, 0.0f),
+                                     STPtrNMDA(0.0f, 0.0f),
+                                     STPtrGABAb(0.0f, 0.0f));
+                                 
+sim.setSTP(CA3_Pyramidal, CA3_MFA_ORDEN, true, STPu(0.14716404225000002f, 0.0f),
+                                     STPtauU(29.01335489f, 0.0f),
+                                     STPtauX(444.9925289f, 0.0f),
+                                     STPtdAMPA(5.948303553f, 0.0f),
+                                     STPtdNMDA(150.0f, 0.0f),
+                                     STPtdGABAa(6.0f, 0.0f),
+                                     STPtdGABAb(150.0f, 0.0f),
+                                     STPtrNMDA(0.0f, 0.0f),
+                                     STPtrGABAb(0.0f, 0.0f));
+                                 
+sim.setSTP(CA3_Pyramidal, CA3_Pyramidal, true, STPu(0.27922089865f, 0.0f),
+                                     STPtauU(21.44820657f, 0.0f),
+                                     STPtauX(318.510891f, 0.0f),
+                                     STPtdAMPA(10.21893984f, 0.0f),
+                                     STPtdNMDA(150.0f, 0.0f),
+                                     STPtdGABAa(6.0f, 0.0f),
+                                     STPtdGABAb(150.0f, 0.0f),
+                                     STPtrNMDA(0.0f, 0.0f),
+                                     STPtrGABAb(0.0f, 0.0f));
+
+/*
+sim.setNeuronMonitor(CA3_QuadD_LM, "DEFAULT");
+                                 
+sim.setNeuronMonitor(CA3_Axo_Axonic, "DEFAULT");
+                                 
+sim.setNeuronMonitor(CA3_Basket, "DEFAULT");
+                                 
+sim.setNeuronMonitor(CA3_BC_CCK, "DEFAULT");
+                                 
+sim.setNeuronMonitor(CA3_Bistratified, "DEFAULT");
+                                 
+sim.setNeuronMonitor(CA3_Ivy, "DEFAULT");
+                                 
+sim.setNeuronMonitor(CA3_MFA_ORDEN, "DEFAULT");
+                                 
+sim.setNeuronMonitor(CA3_Pyramidal, "DEFAULT");
+*/
+
+//NeuronMonitor* nrnMon_Pyramidal = sim.setNeuronMonitor(CA3_Pyramidal, "DEFAULT");
+
+//NeuronMonitor* nrnMon_QuadD_LM = sim.setNeuronMonitor(CA3_QuadD_LM, "DEFAULT");
+
+

--- a/carlsim/testca3/generateSETUPStateSTP.h
+++ b/carlsim/testca3/generateSETUPStateSTP.h
@@ -1,0 +1,36 @@
+
+
+sim.setSpikeMonitor(CA3_QuadD_LM, "DEFAULT");
+                                 
+sim.setSpikeMonitor(CA3_Axo_Axonic, "DEFAULT");
+                                 
+sim.setSpikeMonitor(CA3_Basket, "DEFAULT");
+                                 
+sim.setSpikeMonitor(CA3_BC_CCK, "DEFAULT");
+                                 
+sim.setSpikeMonitor(CA3_Bistratified, "DEFAULT");
+                                 
+sim.setSpikeMonitor(CA3_Ivy, "DEFAULT");
+                                 
+sim.setSpikeMonitor(CA3_MFA_ORDEN, "DEFAULT");
+                                 
+sim.setSpikeMonitor(CA3_Pyramidal, "DEFAULT");
+                               
+
+/*
+sim.setSpikeMonitor(CA3_QuadD_LM, "NULL");
+
+sim.setSpikeMonitor(CA3_Axo_Axonic, "NULL");
+
+sim.setSpikeMonitor(CA3_Basket, "NULL");
+
+sim.setSpikeMonitor(CA3_BC_CCK, "NULL");
+
+sim.setSpikeMonitor(CA3_Bistratified, "NULL");
+
+sim.setSpikeMonitor(CA3_Ivy, "NULL");
+
+sim.setSpikeMonitor(CA3_MFA_ORDEN, "NULL");
+
+sim.setSpikeMonitor(CA3_Pyramidal, "NULL");
+*/


### PR DESCRIPTION
This code is designed to fix [issue 18](https://github.com/UCI-CARL/CARLsim6/issues/18). This fix is for CSTP code incorrectly processing conductance decays in synaptic signals. More details are described on the issue 18 page.