### PR TITLE
Handling multiple snapshots in ConnectionReader.m

### DIFF
--- a/tools/offline_analysis_toolbox/ConnectionReader.m
+++ b/tools/offline_analysis_toolbox/ConnectionReader.m
@@ -148,7 +148,7 @@ classdef ConnectionReader < handle
         end
         
         function [timeStamps, weights] = readWeights(obj, snapShots)
-            if nargin<2 || isempty(snapShots) || snapShots==-1
+            if nargin<2 || isempty(snapShots) || any(snapShots(:) == -1)
                 snapShots = 1:obj.nSnapshots;
             end
             


### PR DESCRIPTION
In the OAT, checking `snapShots==-1` fails and exists when there are multiple snapShots. Changed the expression to `any(snapShots(:) == -1)` to ensure that multiple snapShots can also be checked.