### PR TITLE
Add missing include for sstream, required for std::ostringstream

### DIFF
--- a/carlsim/kernel/inc/snn.h
+++ b/carlsim/kernel/inc/snn.h
@@ -103,6 +103,7 @@
 #include <cassert>
 #include <cstdio>
 #include <climits>
+#include <sstream>
 
 // experimental
 #include <mutex>


### PR DESCRIPTION
Related build failure:
```
/home/tobias/mambaforge/conda-bld/carlsim6_1711409603953/work/carlsim/kernel/src/snn_cpu_module.cpp: In member function 'void SNN::findWavefrontPath_CPU(std::vector<int>&, std::vector<float>&, int, int, int, int)':
/home/tobias/mambaforge/conda-bld/carlsim6_1711409603953/work/carlsim/kernel/src/snn_cpu_module.cpp:1025:36: error: aggregate 'std::ostringstream string_stream' has incomplete type and cannot be defined
 1025 |                 std::ostringstream string_stream;
      |                                    ^~~~~~~~~~~~~
```