### PR TITLE
Fixup CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
-project(carlsim)
-
 cmake_minimum_required(VERSION 3.21.0)
+
+project(carlsim)
 
 # specify the C++ standard aligned to YARP
 set(CMAKE_CXX_STANDARD 14)


### PR DESCRIPTION
Fixes:
```
CMake Warning (dev) at CMakeLists.txt:1 (project):
  cmake_minimum_required() should be called prior to this top-level project()
  call.  Please see the cmake-commands(7) manual for usage documentation of
  both commands.
This warning is for project developers.  Use -Wno-dev to suppress it.
```