### PR TITLE
Feat/no cuda timer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,6 +106,7 @@ endif()
 set(interface_SRCS     
 	carlsim/interface/src/callback_core.cpp
 	carlsim/interface/src/carlsim.cpp
+	carlsim/interface/src/execution_stopwatch.cpp
 	carlsim/interface/src/linear_algebra.cpp
 	carlsim/interface/src/poisson_rate.cpp
 	carlsim/interface/src/user_errors.cpp
@@ -119,6 +120,7 @@ set(interface_HDRS
 	carlsim/interface/inc/carlsim_api.h
 	carlsim/interface/inc/carlsim_conf_api.h
 	carlsim/interface/inc/carlsim_log_definitions.h
+	carlsim/interface/inc/execution_stopwatch.h
 	carlsim/interface/inc/linear_algebra.h
 	carlsim/interface/inc/poisson_rate.h
 	carlsim/interface/inc/user_errors.h

--- a/carlsim/interface/CMakeLists.txt
+++ b/carlsim/interface/CMakeLists.txt
@@ -3,6 +3,7 @@
     add_library(carlsim-interface 
         src/callback_core.cpp
         src/carlsim.cpp
+	src/execution_stopwatch.cpp
         src/linear_algebra.cpp
         src/poisson_rate.cpp
         src/user_errors.cpp
@@ -53,6 +54,7 @@
             inc/carlsim_definitions.h
             inc/carlsim.h
             inc/carlsim_log_definitions.h
+	    inc/execution_stopwatch.h
             inc/linear_algebra.h
             inc/poisson_rate.h
             inc/user_errors.h

--- a/carlsim/interface/inc/execution_stopwatch.h
+++ b/carlsim/interface/inc/execution_stopwatch.h
@@ -1,0 +1,103 @@
+/* * Copyright (c) 2016 Regents of the University of California. All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions
+* are met:
+*
+* 1. Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in the
+*    documentation and/or other materials provided with the distribution.
+*
+* 3. The names of its contributors may not be used to endorse or promote
+*    products derived from this software without specific prior written
+*    permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+* "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+* LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+* A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+* CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+* EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+* PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+* PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+* SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+* *********************************************************************************************** *
+* CARLsim
+* created by: (MDR) Micah Richert, (JN) Jayram M. Nageswaran
+* maintained by:
+* (MA) Mike Avery <averym@uci.edu>
+* (MB) Michael Beyeler <mbeyeler@uci.edu>,
+* (KDC) Kristofor Carlson <kdcarlso@uci.edu>
+* (TSC) Ting-Shuo Chou <tingshuc@uci.edu>
+* (HK) Hirak J Kashyap <kashyaph@uci.edu>
+*
+* CARLsim v1.0: JM, MDR
+* CARLsim v2.0/v2.1/v2.2: JM, MDR, MA, MB, KDC
+* CARLsim3: MB, KDC, TSC
+* CARLsim4: TSC, HK
+* CARLsim5: HK, JX, KC
+* CARLsim6: LN, JX, KC, KW
+*
+* CARLsim available from http://socsci.uci.edu/~jkrichma/CARLsim/
+* Ver 12/31/2016
+*/
+
+#ifndef _EXECUTION_STOPWATCH_H_
+#define _EXECUTION_STOPWATCH_H_
+
+#ifdef __NO_CUDA__
+
+#include "carlsim_api.h"
+
+#include <chrono> // std::chrono::steady_clock::time_point
+
+/*!
+ * \brief A stopwatch class for measuring program execution time
+ * 
+ * This class implements a class for a stopwatch object that can be used to measure the runtime for
+ * a program or a part of it when CARLsim is not run on the GPU. The stopwatch is started at the
+ * beginning of the part of the program to be measured and stopped at the end. After a measurement,
+ * the stopwatch can be used to get the time elapsed and reset for a new measurement.
+ */
+class CARLSIM_API ExecutionStopwatch
+{
+private:
+	bool _timer_on; //!< true if the timer is on, false if off
+	std::chrono::steady_clock::time_point _start_time; //!< time point when the stopwatch is started
+	std::chrono::steady_clock::time_point _stop_time; //!< time point when the stopwatch is stopped
+
+public:
+	/*!
+	 * \brief Starts the stopwatch by recording the time it was started
+	 */
+	void start();
+
+	/*!
+	 * \brief Stops the stopwatch by recording the time it was stopped
+	 */
+	void stop();
+
+	/*!
+	 * \brief Gets the time measured by the stopwatch (time between start and stop time)
+	 * 
+	 * This function returns the time measured by the stopwatch, specifically the difference between
+	 * the start and stop time. If the timer has not been stopped, a time of 0 will be returned.
+	 * 
+	 * \returns the time measured by the stopwatch (s)
+	 */
+	float get_time();
+
+	/*!
+	 * \brief Resets the stopwatch by clearing the currently stored start and stop times
+	 */
+	void reset();
+};
+#endif
+
+#endif // _EXECUTION_STOPWATCH_H_

--- a/carlsim/interface/src/execution_stopwatch.cpp
+++ b/carlsim/interface/src/execution_stopwatch.cpp
@@ -1,0 +1,97 @@
+/* * Copyright (c) 2016 Regents of the University of California. All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions
+* are met:
+*
+* 1. Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in the
+*    documentation and/or other materials provided with the distribution.
+*
+* 3. The names of its contributors may not be used to endorse or promote
+*    products derived from this software without specific prior written
+*    permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+* "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+* LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+* A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+* CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+* EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+* PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+* PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+* SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+* *********************************************************************************************** *
+* CARLsim
+* created by: (MDR) Micah Richert, (JN) Jayram M. Nageswaran
+* maintained by:
+* (MA) Mike Avery <averym@uci.edu>
+* (MB) Michael Beyeler <mbeyeler@uci.edu>,
+* (KDC) Kristofor Carlson <kdcarlso@uci.edu>
+* (TSC) Ting-Shuo Chou <tingshuc@uci.edu>
+* (HK) Hirak J Kashyap <kashyaph@uci.edu>
+*
+* CARLsim v1.0: JM, MDR
+* CARLsim v2.0/v2.1/v2.2: JM, MDR, MA, MB, KDC
+* CARLsim3: MB, KDC, TSC
+* CARLsim4: TSC, HK
+* CARLsim5: HK, JX, KC
+* CARLsim6: LN, JX, KC, KW
+*
+* CARLsim available from http://socsci.uci.edu/~jkrichma/CARLsim/
+* Ver 12/31/2016
+*/
+#include "execution_stopwatch.h"
+
+#include <carlsim_log_definitions.h> // CARLSIM_WARN
+
+void ExecutionStopwatch::start() {
+	if (_timer_on) {
+		CARLSIM_WARN("ExecutionStopwatch::start", "Cannot start timer when timer is on.");
+	}
+	else {
+		_start_time = std::chrono::steady_clock::now();
+		_timer_on = true;
+	}
+}
+
+void ExecutionStopwatch::stop() {
+	if (_timer_on) {
+		_stop_time = std::chrono::steady_clock::now();
+		_timer_on = false;
+	}
+	else {
+		CARLSIM_WARN("ExecutionStopwatch::stop", "Cannot stop timer when timer is off.");
+	}
+}
+
+float ExecutionStopwatch::get_time() {
+	if (_timer_on) {
+		CARLSIM_WARN("ExecutionStopwatch::get_time", "Cannot get time when timer when timer is on.");
+
+		return 0.0f;
+	}
+	else {
+		// Return difference of start and stop times as a float
+		std::chrono::duration<float> measured_time = _stop_time - _start_time;
+
+		return measured_time.count();
+	}
+}
+
+void ExecutionStopwatch::reset() {
+	if (_timer_on) {
+		CARLSIM_WARN("ExecutionStopwatch::reset", "Cannot reset when timer when timer is on.");
+	}
+	else {
+		// Set start and stop times to beginning of clock
+		_start_time = std::chrono::steady_clock::time_point::min();
+		_stop_time = std::chrono::steady_clock::time_point::min();
+	}
+}

--- a/carlsim/kernel/inc/snn.h
+++ b/carlsim/kernel/inc/snn.h
@@ -1226,7 +1226,7 @@ private:
 	void printEntrails_GPU(int netId, int lGrpIdPre, int lGrpIdPost);
 	void printEntrails_GPU(char* buffer, unsigned length, int netId, int lGrpIdPre, int lGrpIdPost);
 #else	                   
-	bool updateDelays_GPU(int netId, int lGrpIdPre, int lGrpIdPost, std::vector<std::tuple<int, int, uint8_t>> connDelays) { assert(false); }
+	bool updateDelays_GPU(int netId, int lGrpIdPre, int lGrpIdPost, std::vector<std::tuple<int, int, uint8_t>> connDelays) { assert(false); return false; }
 	void printEntrails_GPU(int netId, int lGrpIdPre, int lGrpIdPost) { assert(false); }
 	void printEntrails_GPU(char* buffer, unsigned length, int netId, int lGrpIdPre, int lGrpIdPost) { assert(false); }
 #endif

--- a/carlsim/kernel/inc/snn.h
+++ b/carlsim/kernel/inc/snn.h
@@ -109,6 +109,7 @@
 
 #include <carlsim.h>
 #include <callback_core.h>
+#include <execution_stopwatch.h>
 
 #include <snn_definitions.h>
 #include <snn_datastructures.h>
@@ -1317,6 +1318,8 @@ private:
 	//! vairables for tracking performance
 #ifndef __NO_CUDA__
 	StopWatchInterface* timer;
+#else
+	ExecutionStopwatch* timer;
 #endif
 	float cumExecutionTime;
 	float lastExecutionTime;

--- a/carlsim/kernel/src/snn_cpu_module.cpp
+++ b/carlsim/kernel/src/snn_cpu_module.cpp
@@ -49,6 +49,7 @@
 */
 
 #include <snn.h>
+#include <sstream>
 #include <error_code.h>
 
 #include <spike_buffer.h>
@@ -1029,8 +1030,7 @@ void SNN::copyExtFiringTable(int netId) {
 				current_time = rtD.firingTimesD2[last];
 				appendToPath(current, current_time);
 		}
-#if defined(WIN32) && defined(__NO_CUDA__)
-#else
+
 		std::ostringstream string_stream;
 		for (auto iter = path.rbegin(); iter < path.rend(); iter++) {
 			if (iter != path.rbegin())
@@ -1038,7 +1038,6 @@ void SNN::copyExtFiringTable(int netId) {
 			string_stream << *iter;
 		}
 		KERNEL_INFO("path: %s", string_stream.str().c_str());
-#endif
 
 
 #ifndef LN_ELIGIBILITY_INSEARCH

--- a/carlsim/kernel/src/snn_cpu_module.cpp
+++ b/carlsim/kernel/src/snn_cpu_module.cpp
@@ -997,10 +997,18 @@ void SNN::copyExtFiringTable(int netId) {
 				else {
 
 					
+#if defined(WIN32) && defined(__NO_CUDA__)
 #ifdef LN_MOST_RECENT
-					j_max = std::max(j_max, j_fired);  
+					j_max = std::max<int>(j_max, j_fired);
+#else
+					j_min = std::min<int>(j_min, j_fired);
+#endif
+#else
+#ifdef LN_MOST_RECENT
+					j_max = std::max(j_max, j_fired);
 #else
 					j_min = std::min(j_min, j_fired);
+#endif
 #endif
 				}
 			}
@@ -1021,15 +1029,16 @@ void SNN::copyExtFiringTable(int netId) {
 				current_time = rtD.firingTimesD2[last];
 				appendToPath(current, current_time);
 		}
-
+#if defined(WIN32) && defined(__NO_CUDA__)
+#else
 		std::ostringstream string_stream;
 		for (auto iter = path.rbegin(); iter < path.rend(); iter++) {
 			if (iter != path.rbegin())
 				string_stream << ",";
 			string_stream << *iter;
 		}
-
 		KERNEL_INFO("path: %s", string_stream.str().c_str());
+#endif
 
 
 #ifndef LN_ELIGIBILITY_INSEARCH

--- a/carlsim/kernel/src/snn_manager.cpp
+++ b/carlsim/kernel/src/snn_manager.cpp
@@ -8333,7 +8333,12 @@ void SNN::updateNeuronMonitor(int gGrpId) {
 			int grpNumNeurons = groupConfigs[netId][lGrpId].lEndN - groupConfigs[netId][lGrpId].lStartN + 1;
 			//printf("The lStartN is: %i; and lEndN is: %i\n", groupConfigs[netId][lGrpId].lStartN, groupConfigs[netId][lGrpId].lEndN);
 			// for (int lNId = groupConfigs[netId][lGrpId].lStartN; lNId <= groupConfigs[netId][lGrpId].lEndN; lNId++) {
+
+#if defined(WIN32) && defined(__NO_CUDA__)
+			for (int tmpNId = 0; tmpNId < std::min<int>(MAX_NEURON_MON_GRP_SZIE, grpNumNeurons); tmpNId++) {
+#else
 			for (int tmpNId = 0; tmpNId < std::min(MAX_NEURON_MON_GRP_SZIE, grpNumNeurons); tmpNId++) {
+#endif
 				int lNId = groupConfigs[netId][lGrpId].lStartN + tmpNId;
 				float v, u, I;
 
@@ -8404,7 +8409,14 @@ void SNN::printSimSummary() {
 	KERNEL_INFO("Random Seed:\t\t%d", randSeed_);
 	KERNEL_INFO("Timing:\t\t\tModel Simulation Time = %lld sec", (unsigned long long)simTimeSec);
 	KERNEL_INFO("\t\t\tActual Execution Time = %4.2f sec", etime/1000.0f);
-	float speed = float(simTimeSec) / std::max(.001f, etime / 1000.0f); 
+
+#if defined(WIN32) && defined(__NO_CUDA__)
+	float speed = float(simTimeSec) / std::max<float>(.001f, etime / 1000.0f);
+#else
+	float speed = float(simTimeSec) / std::max(.001f, etime / 1000.0f);
+#endif
+
+
 #ifdef _DEBUG
 	const char* build = "(Debug)";
 #else

--- a/carlsim/monitor/neuron_monitor_core.cpp
+++ b/carlsim/monitor/neuron_monitor_core.cpp
@@ -75,7 +75,11 @@ NeuronMonitorCore::NeuronMonitorCore(SNN* snn, int monitorId, int grpId) {
 }
 
 void NeuronMonitorCore::init() {
-	nNeurons_ = std::min(MAX_NEURON_MON_GRP_SZIE, snn_->getGroupNumNeurons(grpId_));	
+#if defined(WIN32) && defined(__NO_CUDA__)
+	nNeurons_ = std::min<int>(MAX_NEURON_MON_GRP_SZIE, snn_->getGroupNumNeurons(grpId_));
+#else
+	nNeurons_ = std::min(MAX_NEURON_MON_GRP_SZIE, snn_->getGroupNumNeurons(grpId_));
+#endif
 	assert(nNeurons_>0);
 
 	// so the first dimension is neuron ID

--- a/carlsim/test/CMakeLists.txt
+++ b/carlsim/test/CMakeLists.txt
@@ -23,6 +23,7 @@ endif()
         conn_mon.cpp
         core.cpp
         cuba.cpp
+	exec_stopwatch.cpp
         group_mon.cpp
         interface.cpp
         main.cpp

--- a/carlsim/test/exec_stopwatch.cpp
+++ b/carlsim/test/exec_stopwatch.cpp
@@ -1,0 +1,103 @@
+/* * Copyright (c) 2016 Regents of the University of California. All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions
+* are met:
+*
+* 1. Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in the
+*    documentation and/or other materials provided with the distribution.
+*
+* 3. The names of its contributors may not be used to endorse or promote
+*    products derived from this software without specific prior written
+*    permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+* "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+* LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+* A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+* CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+* EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+* PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+* PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+* SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+* *********************************************************************************************** *
+* CARLsim
+* created by: (MDR) Micah Richert, (JN) Jayram M. Nageswaran
+* maintained by:
+* (MA) Mike Avery <averym@uci.edu>
+* (MB) Michael Beyeler <mbeyeler@uci.edu>,
+* (KDC) Kristofor Carlson <kdcarlso@uci.edu>
+* (TSC) Ting-Shuo Chou <tingshuc@uci.edu>
+* (HK) Hirak J Kashyap <kashyaph@uci.edu>
+*
+* CARLsim v1.0: JM, MDR
+* CARLsim v2.0/v2.1/v2.2: JM, MDR, MA, MB, KDC
+* CARLsim3: MB, KDC, TSC
+* CARLsim4: TSC, HK
+* CARLsim5: HK, JX, KC
+* CARLsim6: LN, JX, KC, KW
+*
+* CARLsim available from http://socsci.uci.edu/~jkrichma/CARLsim/
+* Ver 12/31/2016
+*/
+#include "gtest/gtest.h"
+#include "carlsim_tests.h"
+
+//#include <carlsim.h>
+
+#ifndef __NO_CUDA__
+#include <cuda_version_control.h>
+#else
+#include <execution_stopwatch.h>
+#endif
+
+#include <thread>
+
+// tests whether the stopwatch functionality used to get the simulation's actual execution time works correctly
+TEST(Stopwatch, ExecutionStopwatch) {
+	// Create timer object
+#ifndef __NO_CUDA__
+	StopWatchInterface* timer;
+	CUDA_CREATE_TIMER(timer);
+#else
+	ExecutionStopwatch* timer = new ExecutionStopwatch{};
+#endif
+
+	for (int i = 0; i <= 100; ++i) {
+		// Start timer
+#ifndef __NO_CUDA__
+		CUDA_START_TIMER(timer)
+#else
+		timer->start();
+#endif
+
+		std::this_thread::sleep_for(std::chrono::milliseconds(i));
+
+		// Stop timer, get time elapsed, and reset timer
+#ifndef __NO_CUDA__
+		CUDA_STOP_TIMER(timer);
+		float measured_time = CUDA_GET_TIMER_VALUE(timer);
+		CUDA_RESET_TIMER(timer);
+#else
+		timer->stop();
+		float measured_time = timer->get_time() * 1000;
+		timer->reset();
+#endif
+
+		float measured_expected_diff = measured_time - i;
+		EXPECT_LE(1e-6, measured_expected_diff);
+	}
+
+#ifndef __NO_CUDA__
+	CUDA_DELETE_TIMER(timer);
+#else
+	delete timer;
+#endif
+}


### PR DESCRIPTION
Added ability to measure actual execution time when running on CPU.

Though the test case added at \carlsim\test\exec_stopwatch.cpp supports running on a GPU, that feature still has yet to be tested. If possible, can you test if \carlsim\test\exec_stopwatch.cpp works when CARLSIM_NO_CUDA flag is off?